### PR TITLE
Modifications to improve memory footprint

### DIFF
--- a/src/hid/MidiEvent.h
+++ b/src/hid/MidiEvent.h
@@ -39,10 +39,10 @@ class SysexChunk
     enum Type : uint8_t
     {
         Invalid,
-        Complete,
-        First,
-        Intermediate,
-        Last
+        Individual,
+        SeqFirst,
+        SeqIntermediate,
+        SeqLast
     };
 
     SysexChunk()

--- a/src/hid/audio.h
+++ b/src/hid/audio.h
@@ -6,9 +6,9 @@
 namespace daisy
 {
 /** @brief Audio Engine Handle
- *  @ingroup audio 
+ *  @ingroup audio
  *  @details This class allows for higher level access to an audio engine.
- *           If you're using a SOM like the DaisySeed or DaisyPatchSM (or any 
+ *           If you're using a SOM like the DaisySeed or DaisyPatchSM (or any
  *            board that includes one of those objects) then the intialization
  *            is already taken  care of.
  *           If you're setting up your own custom hardware, or need to make changes
@@ -49,17 +49,17 @@ class AudioHandle
     };
 
     /** Non-Interleaving input buffer
-     * Buffer arranged by float[chn][sample] 
+     * Buffer arranged by float[chn][sample]
      * const so that the user can't modify the input
      */
     typedef const float* const* InputBuffer;
 
     /** Non-Interleaving output buffer
-     * Arranged by float[chn][sample] 
+     * Arranged by float[chn][sample]
      */
     typedef float** OutputBuffer;
 
-    /** Type for a Non-Interleaving audio callback 
+    /** Type for a Non-Interleaving audio callback
      * Non-Interleaving audio callbacks in daisy will be of this type
      */
     typedef void (*AudioCallback)(InputBuffer  in,
@@ -72,12 +72,12 @@ class AudioHandle
     */
     typedef const float* InterleavingInputBuffer;
 
-    /** Interleaving Output buffer 
+    /** Interleaving Output buffer
      ** audio is prepared as { L0, R0, L1, R1, . . . LN, RN }
     */
     typedef float* InterleavingOutputBuffer;
 
-    /** Interleaving Audio Callback 
+    /** Interleaving Audio Callback
      * Interleaving audio callbacks in daisy must be of this type
      */
     typedef void (*InterleavingAudioCallback)(InterleavingInputBuffer  in,
@@ -102,7 +102,7 @@ class AudioHandle
     /** Returns the Global Configuration struct for the Audio */
     const Config& GetConfig() const;
 
-    /** Returns the number of channels of audio.  
+    /** Returns the number of channels of audio.
      **
      ** When using a single SAI this returns 2, when using two SAI it returns 4
      ** If no SAI is initialized this returns 0
@@ -118,13 +118,13 @@ class AudioHandle
     Result SetSampleRate(SaiHandle::Config::SampleRate samplerate);
 
     /** Sets the block size after initialization, and updates the internal configuration struct.
-     ** Get BlockSize and other details via the GetConfig 
+     ** Get BlockSize and other details via the GetConfig
      */
     Result SetBlockSize(size_t size);
 
     /** Sets the amount of gain adjustment to perform before and after callback.
-     ** useful if the hardware has additional headroom, and the nominal value shouldn't be 1.0 
-     ** 
+     ** useful if the hardware has additional headroom, and the nominal value shouldn't be 1.0
+     **
      ** \param val Gain adjustment amount. The hardware will clip at the reciprical of this value. */
     Result SetPostGain(float val);
 
@@ -139,8 +139,9 @@ class AudioHandle
     /** Starts the Audio using the non-interleaving callback. */
     Result Start(AudioCallback callback);
 
-    /** Starts the Audio using the interleaving callback. 
-     ** For now only two channels are supported via this method. 
+    /** Starts the Audio using the interleaving callback.
+     ** For now only two channels are supported via this method.
+     ** @warning INTERLEAVING CALLBACKS DISABLED IN THIS BRANCH
      */
     Result Start(InterleavingAudioCallback callback);
 
@@ -150,7 +151,9 @@ class AudioHandle
     /** Immediatley changes the audio callback to the non-interleaving callback passed in. */
     Result ChangeCallback(AudioCallback callback);
 
-    /** Immediatley changes the audio callback to the interleaving callback passed in. */
+    /** Immediatley changes the audio callback to the interleaving callback passed in.
+     ** @warning INTERLEAVING CALLBACKS DISABLED IN THIS BRANCH
+     */
     Result ChangeCallback(InterleavingAudioCallback callback);
 
 

--- a/src/hid/midi_parser.h
+++ b/src/hid/midi_parser.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "hid/MidiEvent.h"
+#include "util/ringbuffer.h"
 
 namespace daisy
 {
@@ -15,7 +16,7 @@ namespace daisy
 class MidiParser
 {
   public:
-    MidiParser(){};
+    MidiParser() {};
     ~MidiParser() {}
 
     inline void Init() { Reset(); }
@@ -47,9 +48,15 @@ class MidiParser
         ParserSysEx,
     };
 
-    ParserState     pstate_;
-    MidiEvent       incoming_message_;
-    MidiMessageType running_status_;
+    ParserState                             pstate_;
+    MidiEvent                               incoming_message_;
+    MidiMessageType                         running_status_;
+    RingBuffer<uint8_t, SYSEX_BUF_MAX_SIZE> sysex_buf_;
+    size_t                                  sysex_chunk_len_;
+    size_t                                  sysex_chunk_count_;
+    bool                                    sysex_overflow_;
+
+    void produceSysexChunk(MidiEvent *event_out, bool msg_ended);
 
     // Masks to check for message type, and byte content
     const uint8_t kStatusByteMask     = 0x80;

--- a/src/per/sai.cpp
+++ b/src/per/sai.cpp
@@ -69,7 +69,7 @@ static void Error_Handler()
 // Static References for available SaiHandle::Impls
 // ================================================================
 
-static SaiHandle::Impl sai_handles[2];
+static SaiHandle::Impl sai_handles[1];
 
 // ================================================================
 // SAI Functions
@@ -156,19 +156,19 @@ SaiHandle::Result SaiHandle::Impl::Init(const SaiHandle::Config& config)
     uint32_t protocol;
     switch(config.bit_depth)
     {
-        case Config::BitDepth::SAI_16BIT:
-            bd       = SAI_PROTOCOL_DATASIZE_16BIT;
-            protocol = SAI_I2S_STANDARD;
-            break;
+        // case Config::BitDepth::SAI_16BIT:
+        //     bd       = SAI_PROTOCOL_DATASIZE_16BIT;
+        //     protocol = SAI_I2S_STANDARD;
+        //     break;
         case Config::BitDepth::SAI_24BIT:
             bd       = SAI_PROTOCOL_DATASIZE_24BIT;
             protocol = SAI_I2S_MSBJUSTIFIED;
             break;
-        case Config::BitDepth::SAI_32BIT:
-            // Untested Configuration
-            bd       = SAI_PROTOCOL_DATASIZE_32BIT;
-            protocol = SAI_I2S_STANDARD;
-            break;
+        // case Config::BitDepth::SAI_32BIT:
+        //     // Untested Configuration
+        //     bd       = SAI_PROTOCOL_DATASIZE_32BIT;
+        //     protocol = SAI_I2S_STANDARD;
+        //     break;
         default: break;
     }
 
@@ -453,18 +453,18 @@ extern "C" void HAL_SAI_MspInit(SAI_HandleTypeDef* hsai)
                                    ? SaiHandle::Impl::PeripheralBlock::BLOCK_A
                                    : SaiHandle::Impl::PeripheralBlock::BLOCK_B);
     }
-    else if(hsai->Instance == SAI2_Block_A || hsai->Instance == SAI2_Block_B)
-    {
-        __HAL_RCC_GPIOA_CLK_ENABLE();
-        __HAL_RCC_GPIOD_CLK_ENABLE();
-        __HAL_RCC_GPIOG_CLK_ENABLE();
-        __HAL_RCC_SAI2_CLK_ENABLE();
-        sai_handles[1].InitPins();
-        __HAL_RCC_DMA1_CLK_ENABLE();
-        sai_handles[1].InitDma(hsai->Instance == SAI2_Block_A
-                                   ? SaiHandle::Impl::PeripheralBlock::BLOCK_A
-                                   : SaiHandle::Impl::PeripheralBlock::BLOCK_B);
-    }
+    // else if(hsai->Instance == SAI2_Block_A || hsai->Instance == SAI2_Block_B)
+    // {
+    //     __HAL_RCC_GPIOA_CLK_ENABLE();
+    //     __HAL_RCC_GPIOD_CLK_ENABLE();
+    //     __HAL_RCC_GPIOG_CLK_ENABLE();
+    //     __HAL_RCC_SAI2_CLK_ENABLE();
+    //     sai_handles[1].InitPins();
+    //     __HAL_RCC_DMA1_CLK_ENABLE();
+    //     sai_handles[1].InitDma(hsai->Instance == SAI2_Block_A
+    //                                ? SaiHandle::Impl::PeripheralBlock::BLOCK_A
+    //                                : SaiHandle::Impl::PeripheralBlock::BLOCK_B);
+    // }
 }
 extern "C" void HAL_SAI_MspDeInit(SAI_HandleTypeDef* hsai)
 {
@@ -473,11 +473,11 @@ extern "C" void HAL_SAI_MspDeInit(SAI_HandleTypeDef* hsai)
         __HAL_RCC_SAI1_CLK_DISABLE();
         sai_handles[0].DeInitPins();
     }
-    else if(hsai->Instance == SAI2_Block_A)
-    {
-        __HAL_RCC_SAI2_CLK_DISABLE();
-        sai_handles[1].DeInitPins();
-    }
+    // else if(hsai->Instance == SAI2_Block_A)
+    // {
+    //     __HAL_RCC_SAI2_CLK_DISABLE();
+    //     sai_handles[1].DeInitPins();
+    // }
 }
 
 // ================================================================
@@ -494,15 +494,15 @@ extern "C" void DMA1_Stream1_IRQHandler(void)
     HAL_DMA_IRQHandler(&sai_handles[0].sai_b_dma_handle_);
 }
 
-extern "C" void DMA1_Stream3_IRQHandler(void)
-{
-    HAL_DMA_IRQHandler(&sai_handles[1].sai_a_dma_handle_);
-}
+// extern "C" void DMA1_Stream3_IRQHandler(void)
+// {
+//     HAL_DMA_IRQHandler(&sai_handles[1].sai_a_dma_handle_);
+// }
 
-extern "C" void DMA1_Stream4_IRQHandler(void)
-{
-    HAL_DMA_IRQHandler(&sai_handles[1].sai_b_dma_handle_);
-}
+// extern "C" void DMA1_Stream4_IRQHandler(void)
+// {
+//     HAL_DMA_IRQHandler(&sai_handles[1].sai_b_dma_handle_);
+// }
 
 extern "C" void HAL_SAI_RxHalfCpltCallback(SAI_HandleTypeDef* hsai)
 {
@@ -511,11 +511,11 @@ extern "C" void HAL_SAI_RxHalfCpltCallback(SAI_HandleTypeDef* hsai)
         sai_handles[0].dma_offset = 0;
         sai_handles[0].InternalCallback(0);
     }
-    else if(hsai->Instance == SAI2_Block_A || hsai->Instance == SAI2_Block_B)
-    {
-        sai_handles[1].dma_offset = 0;
-        sai_handles[1].InternalCallback(0);
-    }
+    // else if(hsai->Instance == SAI2_Block_A || hsai->Instance == SAI2_Block_B)
+    // {
+    //     sai_handles[1].dma_offset = 0;
+    //     sai_handles[1].InternalCallback(0);
+    // }
 }
 
 extern "C" void HAL_SAI_RxCpltCallback(SAI_HandleTypeDef* hsai)
@@ -525,11 +525,11 @@ extern "C" void HAL_SAI_RxCpltCallback(SAI_HandleTypeDef* hsai)
         sai_handles[0].dma_offset = sai_handles[0].buff_size_ / 2;
         sai_handles[0].InternalCallback(sai_handles[0].dma_offset);
     }
-    else if(hsai->Instance == SAI2_Block_A || hsai->Instance == SAI2_Block_B)
-    {
-        sai_handles[1].dma_offset = sai_handles[1].buff_size_ / 2;
-        sai_handles[1].InternalCallback(sai_handles[1].dma_offset);
-    }
+    // else if(hsai->Instance == SAI2_Block_A || hsai->Instance == SAI2_Block_B)
+    // {
+    //     sai_handles[1].dma_offset = sai_handles[1].buff_size_ / 2;
+    //     sai_handles[1].InternalCallback(sai_handles[1].dma_offset);
+    // }
 }
 
 // ================================================================
@@ -538,6 +538,10 @@ extern "C" void HAL_SAI_RxCpltCallback(SAI_HandleTypeDef* hsai)
 
 SaiHandle::Result SaiHandle::Init(const Config& config)
 {
+    // SAI2 disabled on this branch
+    if (int(config.periph) > 0)
+        return SaiHandle::Result::ERR;
+
     pimpl_ = &sai_handles[int(config.periph)];
     return pimpl_->Init(config);
 }

--- a/src/per/sai.h
+++ b/src/per/sai.h
@@ -6,20 +6,20 @@
 
 namespace daisy
 {
-/** 
+/**
  * Support for I2S Audio Protocol with different bit-depth, samplerate options
- * Allows for master or slave, as well as freedom of selecting direction, 
+ * Allows for master or slave, as well as freedom of selecting direction,
  * and other behavior for each peripheral, and block.
- * 
+ *
  * DMA Transfer commands must use buffers located within non-cached memory or use cache maintenance
  * To declare an unitialized global element in the DMA memory section:
  *    int32_t DSY_DMA_BUFFER_SECTOR my_buffer[96];
  *
- * Callback functions will be called once per half of the buffer. In the above example, 
+ * Callback functions will be called once per half of the buffer. In the above example,
  * the callback function would be called once for every 48 samples.
- * 
+ *
  * Use SAI Handle like this:
- * 
+ *
  *  SaiHandle::Config sai_config;
  *  sai_config.periph          = SaiHandle::Config::Peripheral::SAI_1;
  *  sai_config.sr              = SaiHandle::Config::SampleRate::SAI_48KHZ;
@@ -49,6 +49,7 @@ class SaiHandle
         enum class Peripheral
         {
             SAI_1,
+            /** NOTE: THIS IS DISABLED ON THIS BRANCH! */
             SAI_2,
         };
 
@@ -65,12 +66,12 @@ class SaiHandle
         /** Bit Depth that the hardware expects to be transferred to/from the device. */
         enum class BitDepth
         {
-            SAI_16BIT,
+            // SAI_16BIT,
             SAI_24BIT,
-            SAI_32BIT,
+            // SAI_32BIT,
         };
 
-        /** Specifies whether a particular block is the master or the slave 
+        /** Specifies whether a particular block is the master or the slave
          ** If both are set to slave, no MCLK signal will be used, and it is
          ** expected that the codec will have its own xtal.
          */
@@ -118,16 +119,16 @@ class SaiHandle
     /** Returns the current configuration */
     const Config& GetConfig() const;
 
-    /** Callback Function to be called when DMA transfer is complete and half complete. 
+    /** Callback Function to be called when DMA transfer is complete and half complete.
      ** This callback is prepared however the data is transmitted/received from the device.
      ** For example, using an AK4556 the data will be interleaved 24bit MSB Justified
-     ** 
+     **
      ** The hid/audio class will be allow for type conversions, de-interleaving, etc.
      */
     typedef void (*CallbackFunctionPtr)(int32_t* in, int32_t* out, size_t size);
 
-    /** Starts Rx and Tx in Circular Buffer Mode 
-     ** The callback will be called when half of the buffer is ready, 
+    /** Starts Rx and Tx in Circular Buffer Mode
+     ** The callback will be called when half of the buffer is ready,
      ** and will handle size/2 samples per callback.
      */
     Result StartDma(int32_t*            buffer_rx,
@@ -141,12 +142,12 @@ class SaiHandle
     /** Returns the samplerate based on the current configuration */
     float GetSampleRate();
 
-    /** Returns the number of samples per audio block 
+    /** Returns the number of samples per audio block
      ** Calculated as Buffer Size / 2 / number of channels */
     size_t GetBlockSize();
 
-    /** Returns the Block Rate of the current stream based on the size 
-     ** of the buffer passed in, and the current samplerate. 
+    /** Returns the Block Rate of the current stream based on the size
+     ** of the buffer passed in, and the current samplerate.
      */
     float GetBlockRate();
 

--- a/src/per/uart.cpp
+++ b/src/per/uart.cpp
@@ -108,15 +108,15 @@ class UartHandler::Impl
                       EndCallbackFunctionPtr   end_callback,
                       void*                    callback_context);
 
-    /** Starts the DMA Reception in "Listen" mode. 
-     *  In this mode the DMA is configured for circular 
+    /** Starts the DMA Reception in "Listen" mode.
+     *  In this mode the DMA is configured for circular
      *  behavior, and the IDLE interrupt is enabled.
-     * 
+     *
      *  At TC, HT, and IDLE interrupts data must be processed.
-     * 
+     *
      *  Size must be set so that at maximum bandwidth, the software
      *  has time to process N bytes before the next circular IRQ is fired
-     * 
+     *
      */
     Result DmaListenStart(uint8_t*                      buff,
                           size_t                        size,
@@ -174,7 +174,7 @@ class UartHandler::Impl
     static EndCallbackFunctionPtr next_end_callback_;
     static void*                  next_callback_context_;
 
-    /** Not static -- any UART can use this 
+    /** Not static -- any UART can use this
      *  until we had dynamic DMA stream handling
      *  this will consume the sole DMA stream for UART Rx
      */


### PR DESCRIPTION
### Disable unused parts of SAI/Audio peripheral classes

* Support for SAI2 (for external codec support) is removed
* Support for interleaved audio callback is removed
* Support for all bit depths except default 24-bit is removed

These changes do not adversely affect the current Nopia hardware configuration, as far as I'm aware, but they end up providing nontrivial savings in both .bss and .text size in the compiled firmware.

### Sysex Parsing Change

Instead of preallocation of sysex buffers and limit to 128bytes per message, use a shared ring buffer and "consumable chunk" wrapper for Sysex message handling, where client must consume bytes from buffer as it handles incoming messages.

This has been tested via example implementation in https://github.com/nopia-suite/nopia-fw/pull/151 including with 4kB continuous sysex dump.