### PR TITLE
SDRAM and Logging Tweaks

### DIFF
--- a/src/daisy_core.h
+++ b/src/daisy_core.h
@@ -23,12 +23,17 @@
 This should be used primarily for DMA buffers, and the like.
 */
 #define DMA_BUFFER_MEM_SECTION __attribute__((section(".sram1_bss")))
-/** 
-THE DTCM RAM section is also non-cached. However, is not suitable 
-for DMA transfers. Performance is on par with internal SRAM w/ 
+/**
+THE DTCM RAM section is also non-cached. However, is not suitable
+for DMA transfers. Performance is on par with internal SRAM w/
 cache enabled.
 */
 #define DTCM_MEM_SECTION __attribute__((section(".dtcmram_bss")))
+
+// Cached region of D2 RAM
+// NOTE: This section can behave strangely on reset,
+//       always be sure to initialize memory
+#define DSY_D2_BSS __attribute__((section(".d2_bss")))
 
 #define FBIPMAX 0.999985f             /**< close to 1.0f-LSB at 16 bit */
 #define FBIPMIN (-FBIPMAX)            /**< - (1 - LSB) */

--- a/src/dev/sdram.cpp
+++ b/src/dev/sdram.cpp
@@ -141,7 +141,7 @@ SdramHandle::Result SdramHandle::DeviceInit()
     HAL_SDRAM_SendCommand(&dsy_sdram.hsdram, &Command, 0x1000);
 
     /* Step 7: Program the external memory mode register */
-    tmpmrd = (uint32_t)SDRAM_MODEREG_BURST_LENGTH_4
+    tmpmrd = (uint32_t)SDRAM_MODEREG_BURST_LENGTH_2
              | SDRAM_MODEREG_BURST_TYPE_SEQUENTIAL | SDRAM_MODEREG_CAS_LATENCY_3
              | SDRAM_MODEREG_WRITEBURST_MODE_SINGLE;
     //SDRAM_MODEREG_OPERATING_MODE_STANDARD | // Used in example, but can't find reference except for "Test Mode"
@@ -154,8 +154,15 @@ SdramHandle::Result SdramHandle::DeviceInit()
     /* Send the command */
     HAL_SDRAM_SendCommand(&dsy_sdram.hsdram, &Command, 0x1000);
 
-    //HAL_SDRAM_ProgramRefreshRate(hsdram, 0x56A - 20);
-    HAL_SDRAM_ProgramRefreshRate(&dsy_sdram.hsdram, 0x81A - 20);
+    // HAL_SDRAM_ProgramRefreshRate(&dsy_sdram.hsdram, 0x81A - 20);
+
+    // optimized refresh rate for 100mhz clock
+    // default libDaisy value is far too big
+    /*
+            Refresh rate = 64ms / 8192 rows = 7.81uS
+            7.81uS * 100Mhz = 781 - 20 = 761
+    */
+    HAL_SDRAM_ProgramRefreshRate(&dsy_sdram.hsdram, 762);
     return Result::OK;
 }
 
@@ -204,7 +211,7 @@ static void HAL_FMC_MspInit(void)
     __HAL_RCC_GPIOC_CLK_ENABLE();
 
 
-    /** FMC GPIO Configuration  
+    /** FMC GPIO Configuration
     PE1   ------> FMC_NBL1
     PE0   ------> FMC_NBL0
     PG15   ------> FMC_SDNCAS
@@ -368,7 +375,7 @@ static void HAL_FMC_MspDeInit(void)
     /* Peripheral clock enable */
     __HAL_RCC_FMC_CLK_DISABLE();
 
-    /** FMC GPIO Configuration  
+    /** FMC GPIO Configuration
     PE1   ------> FMC_NBL1
     PE0   ------> FMC_NBL0
     PG15   ------> FMC_SDNCAS

--- a/src/hid/logger.cpp
+++ b/src/hid/logger.cpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include "logger.h"
 #include "sys/system.h"
+#include "daisy_core.h"
 
 namespace daisy
 {
@@ -128,8 +129,11 @@ template class Logger<LOGGER_EXTERNAL>;
 template class Logger<LOGGER_SEMIHOST>;
 
 /** LoggerImpl static member variables */
-UsbHandle                      LoggerImpl<LOGGER_INTERNAL>::usb_handle_;
-UsbHandle                      LoggerImpl<LOGGER_EXTERNAL>::usb_handle_;
-FIFO<LogMessage, kLogFifoSize> LoggerImpl<LOGGER_INTERNAL>::log_fifo_;
-FIFO<LogMessage, kLogFifoSize> LoggerImpl<LOGGER_EXTERNAL>::log_fifo_;
+UsbHandle LoggerImpl<LOGGER_INTERNAL>::usb_handle_;
+UsbHandle LoggerImpl<LOGGER_EXTERNAL>::usb_handle_;
+
+DSY_D2_BSS FIFO<LogMessage, kLogFifoSize>
+           LoggerImpl<LOGGER_INTERNAL>::log_fifo_;
+DSY_D2_BSS FIFO<LogMessage, kLogFifoSize>
+           LoggerImpl<LOGGER_EXTERNAL>::log_fifo_;
 } // namespace daisy

--- a/src/hid/logger_impl.h
+++ b/src/hid/logger_impl.h
@@ -40,7 +40,7 @@ struct LogMessage
 };
 
 /** FIFO capacity for log messages */
-static const size_t kLogFifoSize = 32;
+static const size_t kLogFifoSize = 128;
 
 /** @brief Logging I/O underlying implementation
  *  @author Alexander Petrov-Savchenko (axp@soft-amp.com)
@@ -76,7 +76,7 @@ class LoggerImpl
     }
 
     /** Wait for host connection (no-op for non-USB destinations) */
-    static void WaitForHostConnection(){};
+    static void WaitForHostConnection() {};
 };
 
 
@@ -268,7 +268,7 @@ class LoggerImpl<LOGGER_SEMIHOST>
     }
 
     /** Wait for host connection (no-op for non-USB destinations) */
-    static void WaitForHostConnection(){};
+    static void WaitForHostConnection() {};
 };
 
 } /* namespace daisy */


### PR DESCRIPTION
### Summary

* Increase log queue size to 128 and place FIFO in D2 SRAM to avoid additional AXI SRAM usage
* Adjust SDRAM refresh cycle count for slightly better SDRAM performance

### Details

In testing the latency reduction stuff I noticed a lot of logs were getting lost, due to the small non-blocking FIFO. I needed to see more of them in order to verify my changes so I bumped the FIFO size up to 128 and moved it into D2 SRAM.

Also I changed the SDRAM refresh cycle count in the libDaisy config - it is *far* too high for what the chip requires. This is something I've tested in my own work quite a bit.

Everything else is autoformatting/whitespace